### PR TITLE
Mikebordon/rebase upstream v1.1.9 jp2k

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM golang:1.14
+FROM golang:1.16
 LABEL maintainer "tomas@aparicio.me"
 
 ARG LIBVIPS_VERSION=8.9.2
 ARG LIBHEIF_VERSION=1.9.1
 ARG GOLANGCILINT_VERSION=1.29.0
+ENV GO111MODULE=off
 
 # Installs libvips + required libraries
 RUN DEBIAN_FRONTEND=noninteractive \
@@ -14,7 +15,8 @@ RUN DEBIAN_FRONTEND=noninteractive \
   gobject-introspection gtk-doc-tools libglib2.0-dev libjpeg62-turbo-dev libpng-dev \
   libwebp-dev libtiff5-dev libgif-dev libexif-dev libxml2-dev libpoppler-glib-dev \
   swig libmagickwand-dev libpango1.0-dev libmatio-dev libopenslide-dev libcfitsio-dev \
-  libgsf-1-dev fftw3-dev liborc-0.4-dev librsvg2-dev libimagequant-dev libaom-dev && \
+  libgsf-1-dev fftw3-dev liborc-0.4-dev librsvg2-dev libimagequant-dev libaom-dev \
+  libopenjp2-7-dev && \
   cd /tmp && \
   curl -fsSLO https://github.com/strukturag/libheif/releases/download/v${LIBHEIF_VERSION}/libheif-${LIBHEIF_VERSION}.tar.gz && \
   tar zvxf libheif-${LIBHEIF_VERSION}.tar.gz && \

--- a/resizer.go
+++ b/resizer.go
@@ -82,7 +82,9 @@ func resizer(buf []byte, o Options) ([]byte, error) {
 	}
 
 	// Try to use libjpeg/libwebp shrink-on-load
-	supportsShrinkOnLoad := imageType == WEBP && VipsMajorVersion >= 8 && VipsMinorVersion >= 3
+	// vips must undershrink on load because this led to super blurry nonsense
+	// supportsShrinkOnLoad := imageType == WEBP && VipsMajorVersion >= 8 && VipsMinorVersion >= 3
+	supportsShrinkOnLoad := false
 	supportsShrinkOnLoad = supportsShrinkOnLoad || imageType == JPEG
 	if supportsShrinkOnLoad && shrink >= 2 {
 		tmpImage, factor, err := shrinkOnLoad(buf, image, imageType, factor, shrink)

--- a/type.go
+++ b/type.go
@@ -32,6 +32,8 @@ const (
 	HEIF
 	// AVIF represents the AVIF image type.
 	AVIF
+	// JP2K represents the JP2K (JPEG-2000) image type.
+	JP2K
 )
 
 var (
@@ -51,6 +53,7 @@ var ImageTypes = map[ImageType]string{
 	MAGICK: "magick",
 	HEIF:   "heif",
 	AVIF:   "avif",
+	JP2K:   "jp2k",
 }
 
 // imageMutex is used to provide thread-safe synchronization

--- a/type_test.go
+++ b/type_test.go
@@ -18,7 +18,7 @@ func TestDeterminateImageType(t *testing.T) {
 		{"test.gif", GIF},
 		{"test.pdf", PDF},
 		{"test.svg", SVG},
-		// {"test.jp2", MAGICK},
+		{"test.jp2", JP2K},
 		{"test.heic", HEIF},
 		{"test2.heic", HEIF},
 		{"test3.heic", HEIF},
@@ -50,7 +50,7 @@ func TestDeterminateImageTypeName(t *testing.T) {
 		{"test.gif", "gif"},
 		{"test.pdf", "pdf"},
 		{"test.svg", "svg"},
-		// {"test.jp2", "magick"},
+		{"test.jp2", "jp2k"},
 		{"test.heic", "heif"},
 		{"test.avif", "avif"},
 	}
@@ -60,6 +60,9 @@ func TestDeterminateImageTypeName(t *testing.T) {
 			continue
 		}
 		if file.expected == "avif" && VipsMajorVersion <= 8 && VipsMinorVersion < 9 {
+			continue
+		}
+		if file.expected == "jp2k" && VipsMajorVersion <= 8 && VipsMinorVersion < 11 {
 			continue
 		}
 
@@ -78,7 +81,7 @@ func TestIsTypeSupported(t *testing.T) {
 	types := []struct {
 		name ImageType
 	}{
-		{JPEG}, {PNG}, {WEBP}, {GIF}, {PDF}, {HEIF}, {AVIF},
+		{JPEG}, {PNG}, {WEBP}, {GIF}, {PDF}, {HEIF}, {AVIF}, {JP2K},
 	}
 
 	for _, n := range types {
@@ -86,6 +89,9 @@ func TestIsTypeSupported(t *testing.T) {
 			continue
 		}
 		if n.name == AVIF && VipsMajorVersion <= 8 && VipsMinorVersion < 9 {
+			continue
+		}
+		if n.name == JP2K && VipsMajorVersion <= 8 && VipsMinorVersion < 11 {
 			continue
 		}
 		if IsTypeSupported(n.name) == false {
@@ -106,6 +112,7 @@ func TestIsTypeNameSupported(t *testing.T) {
 		{"pdf", true},
 		{"heif", true},
 		{"avif", true},
+		{"jp2k", true},
 	}
 
 	for _, n := range types {
@@ -113,6 +120,9 @@ func TestIsTypeNameSupported(t *testing.T) {
 			continue
 		}
 		if n.name == "avif" && VipsMajorVersion <= 8 && VipsMinorVersion < 9 {
+			continue
+		}
+		if n.name == "jp2k" && VipsMajorVersion <= 8 && VipsMinorVersion < 11 {
 			continue
 		}
 		if IsTypeNameSupported(n.name) != n.expected {
@@ -139,6 +149,9 @@ func TestIsTypeSupportedSave(t *testing.T) {
 	if VipsVersion >= "8.12.0" {
 		types = append(types, struct{ name ImageType }{GIF})
 	}
+	if VipsVersion >= "8.11.0" {
+		types = append(types, struct{ name ImageType }{JP2K})
+	}
 
 	for _, n := range types {
 		if IsTypeSupportedSave(n.name) == false {
@@ -160,6 +173,7 @@ func TestIsTypeNameSupportedSave(t *testing.T) {
 		{"heif", VipsVersion >= "8.8.0"},
 		{"avif", VipsVersion >= "8.9.0"},
 		{"gif", VipsVersion >= "8.12.0"},
+		{"jp2k", VipsVersion >= "8.11.0"},
 	}
 
 	for _, n := range types {

--- a/vips.go
+++ b/vips.go
@@ -205,6 +205,9 @@ func VipsIsTypeSupported(t ImageType) bool {
 	if t == AVIF {
 		return int(C.vips_type_find_bridge(C.HEIF)) != 0
 	}
+	if t == JP2K {
+		return int(C.vips_type_find_bridge(C.JP2K)) != 0
+	}
 	return false
 }
 
@@ -232,6 +235,9 @@ func VipsIsTypeSupportedSave(t ImageType) bool {
 	}
 	if t == GIF {
 		return int(C.vips_type_find_save_bridge(C.GIF)) != 0
+	}
+	if t == JP2K {
+		return int(C.vips_type_find_save_bridge(C.JP2K)) != 0
 	}
 	return false
 }
@@ -529,6 +535,8 @@ func vipsSave(image *C.VipsImage, o vipsSaveOptions) ([]byte, error) {
 		saveErr = C.vips_avifsave_bridge(tmpImage, &ptr, &length, strip, quality, lossless, speed)
 	case GIF:
 		saveErr = C.vips_gifsave_bridge(tmpImage, &ptr, &length, strip)
+	case JP2K:
+		saveErr = C.vips_jp2ksave_bridge(tmpImage, &ptr, &length, quality, lossless)
 	default:
 		saveErr = C.vips_jpegsave_bridge(tmpImage, &ptr, &length, strip, quality, interlace)
 	}
@@ -766,6 +774,13 @@ func vipsImageType(buf []byte) ImageType {
 	if IsTypeSupported(HEIF) && buf[4] == 0x66 && buf[5] == 0x74 && buf[6] == 0x79 && buf[7] == 0x70 &&
 		buf[8] == 0x61 && buf[9] == 0x76 && buf[10] == 0x69 && buf[11] == 0x66 {
 		return AVIF
+	}
+	// https://www.iana.org/assignments/media-types/image/jp2
+	// https://www.loc.gov/preservation/digital/formats/fdd/fdd_explanation.shtml#sign
+	if IsTypeSupported(JP2K) && buf[0] == 0x00 && buf[1] == 0x00 && buf[2] == 0x00 && buf[3] == 0x0c &&
+		buf[4] == 0x6a && buf[5] == 0x50 && buf[6] == 0x20 && buf[7] == 0x20 && buf[8] == 0x0d &&
+		buf[9] == 0x0a && buf[10] == 0x87 && buf[11] == 0x0a {
+		return JP2K
 	}
 
 	return UNKNOWN

--- a/vips.h
+++ b/vips.h
@@ -35,7 +35,8 @@ enum types {
 	SVG,
 	MAGICK,
 	HEIF,
-	AVIF
+	AVIF,
+	JP2K
 };
 
 typedef struct {
@@ -164,6 +165,11 @@ vips_type_find_bridge(int t) {
 		return vips_type_find("VipsOperation", "heifload");
 	}
 #endif
+#if (VIPS_MAJOR_VERSION > 8 || (VIPS_MAJOR_VERSION == 8 && VIPS_MINOR_VERSION >= 11))
+	if (t == JP2K) {
+		return vips_type_find("VipsOperation", "jp2kload");
+	}
+#endif
 	return 0;
 }
 
@@ -189,6 +195,11 @@ vips_type_find_save_bridge(int t) {
 #if (VIPS_MAJOR_VERSION > 8 || (VIPS_MAJOR_VERSION == 8 && VIPS_MINOR_VERSION >= 12))
 	if (t == GIF) {
 		return vips_type_find("VipsOperation", "gifsave_buffer");
+	}
+#endif
+#if (VIPS_MAJOR_VERSION > 8 || (VIPS_MAJOR_VERSION == 8 && VIPS_MINOR_VERSION >= 11))
+	if (t == JP2K) {
+		return vips_type_find("VipsOperation", "jp2ksave_buffer");
 	}
 #endif
 	return 0;
@@ -332,6 +343,19 @@ vips_jpegsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int qual
 		"interlace", INT_TO_GBOOLEAN(interlace),
 		NULL
 	);
+}
+
+int
+vips_jp2ksave_bridge(VipsImage *in, void **buf, size_t *len, int quality, int lossless) {
+#if (VIPS_MAJOR_VERSION > 8 || (VIPS_MAJOR_VERSION == 8 && VIPS_MINOR_VERSION >= 11))
+	return vips_jp2ksave_buffer(in, buf, len,
+		"Q", quality,
+		"lossless", INT_TO_GBOOLEAN(lossless),
+		NULL
+	);
+#else
+	return 0;
+#endif
 }
 
 int
@@ -481,6 +505,10 @@ vips_init_image (void *buf, size_t len, int imageType, VipsImage **out) {
 #if (VIPS_MAJOR_VERSION == 8 && VIPS_MINOR_VERSION >= 9)
 	} else if (imageType == AVIF) {
 		code = vips_heifload_buffer(buf, len, out, "access", VIPS_ACCESS_RANDOM, NULL);
+#endif
+#if (VIPS_MAJOR_VERSION > 8 || (VIPS_MAJOR_VERSION == 8 && VIPS_MINOR_VERSION >= 11))
+	} else if (imageType == JP2K) {
+		code = vips_jp2kload_buffer(buf, len, out, "access", VIPS_ACCESS_RANDOM, NULL);
 #endif
 	}
 

--- a/vips_test.go
+++ b/vips_test.go
@@ -74,6 +74,22 @@ func TestVipsSaveAvif(t *testing.T) {
 	}
 }
 
+func TestVipsSaveJp2k(t *testing.T) {
+	if !IsTypeSupportedSave(JP2K) {
+		t.Skipf("Format %#v is not supported", ImageTypes[JP2K])
+	}
+	image, _, _ := vipsRead(readImage("test.jpg"))
+	options := vipsSaveOptions{Quality: 95, Type: JP2K}
+	buf, err := vipsSave(image, options)
+	if err != nil {
+		t.Fatalf("Error saving image type %v: %v", ImageTypes[JP2K], err)
+	}
+
+	if len(buf) == 0 {
+		t.Fatalf("Empty saved '%v' image", ImageTypes[JP2K])
+	}
+}
+
 func TestVipsRotate(t *testing.T) {
 	files := []struct {
 		name   string


### PR DESCRIPTION
ltk-imagesizer is the only repo using bimg, and it's already using bimg 1.1.9 version

ltk-imagesizer go.mod:

	github.com/rewardStyle/bimg v1.0.16-0.20221020012909-2295ae31e0da
[2295ae31e0da commit](https://github.com/rewardStyle/bimg/commit/2295ae31e0da3050cc800929abc26fd67c250d20)
